### PR TITLE
Fix API fetch HTML response

### DIFF
--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,5 +1,11 @@
 // Simple API configuration
 const getBaseUrl = () => {
+  // First, check for environment variable (for production/Render deployment)
+  if (process.env.REACT_APP_API_BASE_URL) {
+    return process.env.REACT_APP_API_BASE_URL;
+  }
+  
+  // Then check hostname for development environments
   const hostname = window.location.hostname;
   
   if (hostname.includes('cloudworkstations.dev') || 
@@ -11,6 +17,7 @@ const getBaseUrl = () => {
     return 'http://localhost:8000';
   }
   
+  // Fallback
   return 'http://localhost:8000';
 };
 


### PR DESCRIPTION
Prioritize `REACT_APP_API_BASE_URL` environment variable for API base URL.

Fixes API errors where the frontend was not using the correct backend URL from environment variables, leading to HTML error pages instead of JSON responses. This issue was introduced by a previous refactoring in PR #6 that removed support for `process.env.REACT_APP_API_BASE_URL`.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-7bfbd579-d5f1-4e07-9e4b-61b7effbff50) · [Cursor](https://cursor.com/background-agent?bcId=bc-7bfbd579-d5f1-4e07-9e4b-61b7effbff50)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)