### PR TITLE
Fix API fetch HTML response

### DIFF
--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -26,14 +26,29 @@ const API_BASE_URL = getBaseUrl();
 const apiRequest = async (endpoint, options = {}) => {
   const url = API_BASE_URL + endpoint;
   
-  return fetch(url, {
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-      ...options.headers,
-    },
-    ...options,
-  });
+  try {
+    const response = await fetch(url, {
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+      ...options,
+    });
+    
+    // Check if response is HTML (error page)
+    const contentType = response.headers.get('content-type');
+    if (contentType && contentType.includes('text/html')) {
+      const htmlText = await response.text();
+      console.error('Received HTML instead of JSON:', htmlText.substring(0, 200));
+      throw new Error(`API returned HTML instead of JSON. Status: ${response.status}`);
+    }
+    
+    return response;
+  } catch (error) {
+    console.error('API request failed:', error);
+    throw error;
+  }
 };
 
 export { API_BASE_URL, apiRequest };


### PR DESCRIPTION
Re-enable `REACT_APP_API_BASE_URL` usage and add HTML response error handling to fix API call failures in deployed environments.

Commit `99a375d` (part of PR #6) inadvertently removed support for `process.env.REACT_APP_API_BASE_URL`, causing API calls to fail when deployed. This PR restores that functionality and adds error handling for non-JSON responses.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-7bfbd579-d5f1-4e07-9e4b-61b7effbff50) · [Cursor](https://cursor.com/background-agent?bcId=bc-7bfbd579-d5f1-4e07-9e4b-61b7effbff50)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)